### PR TITLE
javascript interop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,6 @@ bloom-*.tar
 /bloom_site/npm-debug.log
 /bloom_site/assets/node_modules/
 
-
 /bloom_site/.elixir_ls
+
+node_modules/

--- a/lib/tasks/generate_templates.ex
+++ b/lib/tasks/generate_templates.ex
@@ -4,6 +4,7 @@ defmodule Mix.Tasks.Bloom.GenerateTemplates do
   @shortdoc "Generates EEx templates from Bloom component files."
   def run(_args) do
     components_path = "lib/bloom/components"
+    js_hooks_path = "assets/js"
     templates_path = "priv/templates"
 
     File.ls!(components_path)
@@ -14,6 +15,16 @@ defmodule Mix.Tasks.Bloom.GenerateTemplates do
       File.mkdir_p!(Path.dirname(target_file))
       File.write!(target_file, template_content)
       Mix.shell().info("Generated template: #{target_file}")
+    end)
+
+    # js hooks are let raw for now
+    File.ls!(js_hooks_path)
+    |> Enum.each(fn file ->
+      content = File.read!(Path.join(js_hooks_path, file))
+      target_file = Path.join(templates_path, "#{Path.rootname(file)}.js")
+      File.mkdir_p!(Path.dirname(target_file))
+      File.write!(target_file, content)
+      Mix.shell().info("Generated js hook template: #{target_file}")
     end)
   end
 

--- a/lib/tasks/install.ex
+++ b/lib/tasks/install.ex
@@ -36,6 +36,7 @@ defmodule Mix.Tasks.Bloom.Install do
     env = Mix.env() |> Atom.to_string()
     project_name = Mix.Project.config()[:app] |> Atom.to_string() |> String.downcase()
     source_file = "_build/#{env}/lib/bloom/priv/templates/#{file_name}.ex"
+    js_hook_file = "_build/#{env}/lib/bloom/priv/templates/#{file_name}.js"
 
     if File.exists?(source_file) do
       component_dir = component_dir(project_name)
@@ -48,6 +49,14 @@ defmodule Mix.Tasks.Bloom.Install do
         EEx.eval_file(source_file, module_name: module_name, assigns: %{module_name: module_name})
 
       File.write!(target_path, source_code)
+
+      if File.exists?(js_hook_file) do
+        js_hook_dir = "assets/vendor/hooks"
+        File.mkdir_p(js_hook_dir)
+        js_hook_target_path = "#{js_hook_dir}/#{file_name}.js"
+        File.cp!(js_hook_file, js_hook_target_path)
+      end
+
       Mix.shell().info("#{file_name} component installed successfully ✅ - #{target_path}")
 
       Mix.shell().info(

--- a/lib/tasks/install.ex
+++ b/lib/tasks/install.ex
@@ -50,7 +50,9 @@ defmodule Mix.Tasks.Bloom.Install do
 
       File.write!(target_path, source_code)
 
-      if File.exists?(js_hook_file) do
+      component_includes_js? = File.exists?(js_hook_file)
+
+      if component_includes_js? do
         js_hook_dir = "assets/vendor/hooks"
         File.mkdir_p(js_hook_dir)
         js_hook_target_path = "#{js_hook_dir}/#{file_name}.js"
@@ -62,6 +64,12 @@ defmodule Mix.Tasks.Bloom.Install do
       Mix.shell().info(
         "Don't forget to import the component to your #{project_name |> Macro.underscore()}_web.ex` file."
       )
+
+      if component_includes_js? do
+        Mix.shell().info(
+          "Make sure you import the JS hook in your `app.js` file and add it to the hooks of your Liveview Socket."
+        )
+      end
     else
       Mix.shell().info("Template not found: #{source_file}")
     end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "bloom",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bloom",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@types/phoenix_live_view": "^0.18.4"
+      },
+      "devDependencies": {
+        "phoenix_live_view": "^0.20.14"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.4.tgz",
+      "integrity": "sha512-B34A7uot1Cv0XtaHRYDATltAdKx0BvVKNgYNqE4WjtPUa4VQJM7kxeXcVKaH+KS+kCmZ+6w+QaUdcljiheiBJA=="
+    },
+    "node_modules/@types/phoenix_live_view": {
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@types/phoenix_live_view/-/phoenix_live_view-0.18.4.tgz",
+      "integrity": "sha512-9mq6zRZfCtY8f4Kiu9ca0YodlNoL5kPfz6AO8AMIylftoT59re5+l5BxPISt/NJXyj1S/gRJmwpHgyVsyEk8cg==",
+      "dependencies": {
+        "@types/phoenix": "*"
+      }
+    },
+    "node_modules/phoenix_live_view": {
+      "version": "0.20.14",
+      "resolved": "https://registry.npmjs.org/phoenix_live_view/-/phoenix_live_view-0.20.14.tgz",
+      "integrity": "sha512-pk7xX1CjUaoHRE47S0Rq+OdrGrXRHrZZQEaNbRNCAbKjSEAJ9o+sYQ+6nZipTJaIbC0lEGMDWxZzyuQ/6yeHsQ==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "@types/phoenix": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.4.tgz",
+      "integrity": "sha512-B34A7uot1Cv0XtaHRYDATltAdKx0BvVKNgYNqE4WjtPUa4VQJM7kxeXcVKaH+KS+kCmZ+6w+QaUdcljiheiBJA=="
+    },
+    "@types/phoenix_live_view": {
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@types/phoenix_live_view/-/phoenix_live_view-0.18.4.tgz",
+      "integrity": "sha512-9mq6zRZfCtY8f4Kiu9ca0YodlNoL5kPfz6AO8AMIylftoT59re5+l5BxPISt/NJXyj1S/gRJmwpHgyVsyEk8cg==",
+      "requires": {
+        "@types/phoenix": "*"
+      }
+    },
+    "phoenix_live_view": {
+      "version": "0.20.14",
+      "resolved": "https://registry.npmjs.org/phoenix_live_view/-/phoenix_live_view-0.20.14.tgz",
+      "integrity": "sha512-pk7xX1CjUaoHRE47S0Rq+OdrGrXRHrZZQEaNbRNCAbKjSEAJ9o+sYQ+6nZipTJaIbC0lEGMDWxZzyuQ/6yeHsQ==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "bloom",
+  "version": "0.0.1",
+  "type": "module",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/phoenix_live_view": "^0.18.4",
+    "phoenix_live_view": "^0.20.14"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "bloom",
   "version": "0.0.1",
-  "type": "module",
   "license": "MIT",
   "devDependencies": {
     "@types/phoenix_live_view": "^0.18.4",


### PR DESCRIPTION
## Changes 

This PR adds capability for Javascript hooks to be added to components, and installed alongside Elixir component templates.

## Implementation details

Javascript hooks are authored in the `assets/js/` folder, and are moved alongside the `.ex` templates when `mix bloom.generate_templates` is run. Then on `mix bloom.install X` the JS file is added to `assets/js/vendor/hooks/X.js` 

Just like the Elixir components, it is then up to the consumer of the package to wire up the hook ready for use.

> [!Note]
> I opted for a basic `npm init` to get the types in place for more complex hooks, and Javascript tooling to be added later. 
> If you have strong preference for either `yarn` or `pnpm` (or `bun`) then I'm happy to switch that out

## Testing 

See a new component with hook implemented in #5

