### PR TITLE
fix: default in attr ensures default values

### DIFF
--- a/lib/bloom/components/marquee.ex
+++ b/lib/bloom/components/marquee.ex
@@ -42,13 +42,6 @@ defmodule Bloom.Components.Marquee do
   slot(:inner_block, required: true)
 
   def marquee(assigns) do
-    assigns =
-      assigns
-      |> assign(:repeat, assigns[:repeat] || 4)
-      |> assign(:vertical, assigns[:vertical] || false)
-      |> assign(:pause_on_hover, assigns[:pause_on_hover] || false)
-      |> assign(:reverse, assigns[:reverse] || false)
-
     ~H"""
     <div
       :if={@repeat > 0}

--- a/priv/templates/marquee.ex
+++ b/priv/templates/marquee.ex
@@ -42,13 +42,6 @@ defmodule <%= @module_name %>Web.Components.Marquee do
   slot(:inner_block, required: true)
 
   def marquee(assigns) do
-    assigns =
-      assigns
-      |> assign(:repeat, assigns[:repeat] || 4)
-      |> assign(:vertical, assigns[:vertical] || false)
-      |> assign(:pause_on_hover, assigns[:pause_on_hover] || false)
-      |> assign(:reverse, assigns[:reverse] || false)
-
     ~H"""
     <div
       :if={@repeat > 0}


### PR DESCRIPTION
* no need for explicit assigns 

See `default` https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#attr/3-options